### PR TITLE
Parameters for binding classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,48 @@ Similar to CSS classes, you can list multiple keys and the resulting bindings wi
 
 At run-time, you can also access the bindings, by using `ko.bindingProvider.instance.bindings`.  This allows you to add and remove bindings as your application needs them.
 
+Advanced Usage
+--------------
+You may optionally pass one or more parameters into the binding class by separating them with a colon (`:`). These parameters are passed as additional string arguments into the binding function. Though this makes the markup a little more complex, it offers some flexibility that can reduce the number of binding classes.
+
+For example, to render only the selected section:
+
+```html
+<div data-class="renderSection:overview">...</div>
+<div data-class="renderSection:contact-info">...</div>
+```
+
+```js
+var bindings = {
+	renderSection: function(context, sectionId) {
+		return {
+			'if': this.selectedSectionId() === sectionId
+		}
+	}
+};
+```
+
+Additional parameters are passed as additional arguments to the binding function. At the risk of making binding classes too complex, this opens up some possibilities. This example applies the css class "required-item" if the "phones" array is empty:
+
+```html
+<div data-class="cssIfEmpty:phones:required-item">
+	<h2>Phones</h2>
+	...
+</div>
+```
+
+```js
+var bindings = {
+	cssIfEmpty: function(context, array, css) {
+		var result = {};
+		result[css] = !ko.utils.unwrapObservable(this[array]).length
+		return {
+			css: result
+		};
+	}
+};
+```
+
 Dependencies
 ------------
 * Knockout 2.0+

--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -49,7 +49,7 @@
             var i, j, bindingAccessor, binding,
                 result = {},
                 value, index,
-                classes = "";
+                classes = "", clas;
 
             if (node.nodeType === 1) {
                 classes = node.getAttribute(this.attribute);
@@ -67,9 +67,10 @@
                 classes = classes.split(' ');
                 //evaluate each class, build a single object to return
                 for (i = 0, j = classes.length; i < j; i++) {
-                    bindingAccessor = this.bindings[classes[i]];
+                    clas = classes[i].split(':');
+                    bindingAccessor = this.bindings[clas[0]];
                     if (bindingAccessor) {
-                        binding = typeof bindingAccessor == "function" ? bindingAccessor.call(bindingContext.$data, bindingContext) : bindingAccessor;
+                        binding = typeof bindingAccessor == "function" ? bindingAccessor.apply(bindingContext.$data, [bindingContext].concat(clas.slice(1))) : bindingAccessor;
                         ko.utils.extend(result, binding);
                     }
                 }

--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -59,7 +59,7 @@
                 index = value.indexOf(virtualAttribute);
 
                 if (index > -1) {
-                    classes = value.substring(index);
+                    classes = value.substring(index + virtualAttribute.length);
                 }
             }
 
@@ -67,7 +67,9 @@
                 classes = classes.split(' ');
                 //evaluate each class, build a single object to return
                 for (i = 0, j = classes.length; i < j; i++) {
-                    clas = classes[i].split(':');
+                    clas = classes[i];
+                    if (clas.length === 0) continue;
+                    clas = clas.split(':');
                     bindingAccessor = this.bindings[clas[0]];
                     if (bindingAccessor) {
                         binding = typeof bindingAccessor == "function" ? bindingAccessor.apply(bindingContext.$data, [bindingContext].concat(clas.slice(1))) : bindingAccessor;


### PR DESCRIPTION
Thanks for this plugin. It has bothered me that I couldn't fully separate the code from the markup. However there are cases where binding classes are too restrictive and I'd like a bit more flexibility than the binding class provides. This pull request allows binding class parameters separated by colons (`:`) to be passed in as arguments to the binding function. I feel that this hybrid still brings the benefits of the plugin and gives enough flexibility to be able to turn off the fallback on the built-in binding.

For example, to render only the selected section:

``` html
<div data-class="renderSection:overview">...</div>
<div data-class="renderSection:contact-info">...</div>
<div data-class="renderSection:other-details">...</div>
```

``` js
var bindings = {
    renderSection: function(context, sectionId) {
        return {
            'if': this.selectedSectionId() === sectionId
        }
    }
};
```

Multiple binding class arguments (`binding:arg0:arg1:arg2`) are passed to the binding function as additional parameters (`context, arg0, arg1, arg2`).
