### PR TITLE
Provide access to attributes in binding functions

### DIFF
--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -49,18 +49,34 @@
             var i, j, bindingAccessor, binding,
                 result = {},
                 value, index,
-                classes = "", clas;
+                classes = "", clas,
+                virtualDataAttributes,
+                virtualNode;
 
             if (node.nodeType === 1) {
                 classes = node.getAttribute(this.attribute);
+                virtualNode = node;
             }
             else if (node.nodeType === 8) {
                 value = "" + node.nodeValue || node.text;
                 index = value.indexOf(virtualAttribute);
 
                 if (index > -1) {
-                    classes = value.substring(index + virtualAttribute.length);
+                    virtualDataAttributes = value.substring(index + virtualAttribute.length).split(',');
+                    classes = virtualDataAttributes[0];
+                    virtualDataAttributes = virtualDataAttributes.slice(1);
                 }
+
+                virtualNode = {};
+                virtualNode.getAttribute = function(name) {
+                    return ko.utils.arrayFirst(virtualDataAttributes, function(attr) {
+                        var index = attr.indexOf(name + ":");
+                        if (index > -1) {
+                            return attr.substring(index + name.length + 1).replace(/^(\s|\u00A0)+|(\s|\u00A0)+$/g, '');
+                        }
+                    });
+                };
+
             }
 
             if (classes) {
@@ -71,7 +87,7 @@
                     if (clas.length === 0) continue;
                     bindingAccessor = this.bindings[clas];
                     if (bindingAccessor) {
-                        binding = typeof bindingAccessor == "function" ? bindingAccessor.call(bindingContext.$data, bindingContext) : bindingAccessor;
+                        binding = typeof bindingAccessor == "function" ? bindingAccessor.call(bindingContext.$data, bindingContext, virtualNode) : bindingAccessor;
                         ko.utils.extend(result, binding);
                     }
                 }

--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -69,12 +69,12 @@
 
                 virtualNode = {};
                 virtualNode.getAttribute = function(name) {
-                    return ko.utils.arrayFirst(virtualDataAttributes, function(attr) {
-                        var index = attr.indexOf(name + ":");
-                        if (index > -1) {
-                            return attr.substring(index + name.length + 1).replace(/^(\s|\u00A0)+|(\s|\u00A0)+$/g, '');
-                        }
+                    var foundAttr;
+                    name = name + ":";
+                    foundAttr = ko.utils.arrayFirst(virtualDataAttributes, function(attr) {
+                        return attr.indexOf(name) > -1;
                     });
+                    return foundAttr && foundAttr.split(':')[1].replace(/^(\s|\u00A0)+|(\s|\u00A0)+$/g, '');
                 };
 
             }

--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -49,7 +49,7 @@
             var i, j, bindingAccessor, binding,
                 result = {},
                 value, index,
-                classes = "";
+                classes = "", clas;
 
             if (node.nodeType === 1) {
                 classes = node.getAttribute(this.attribute);
@@ -59,7 +59,7 @@
                 index = value.indexOf(virtualAttribute);
 
                 if (index > -1) {
-                    classes = value.substring(index);
+                    classes = value.substring(index + virtualAttribute.length);
                 }
             }
 
@@ -67,7 +67,9 @@
                 classes = classes.split(' ');
                 //evaluate each class, build a single object to return
                 for (i = 0, j = classes.length; i < j; i++) {
-                    bindingAccessor = this.bindings[classes[i]];
+                    clas = classes[i];
+                    if (clas.length === 0) continue;
+                    bindingAccessor = this.bindings[clas];
                     if (bindingAccessor) {
                         binding = typeof bindingAccessor == "function" ? bindingAccessor.call(bindingContext.$data, bindingContext) : bindingAccessor;
                         ko.utils.extend(result, binding);


### PR DESCRIPTION
As discussed in #1, this gives access to the node in the second parameter of the binding function. For virtual nodes, the node is an object with a getAttribute function. This provides a consistent interface to data-attributes. For example:

``` html
<div data-class="renderSection" data-section="overview">...</div>
```

``` html
<!-- ko class: renderSection, data-section: overview -->...<!-- /ko -->
```

Both of these can be read the same way:

``` js
renderSection: function(context, node) {
    return {
        "if": this.selectedSection() === node.getAttribute('data-section')
    };
}
```
