### PR TITLE
Strict binding class mapping

### DIFF
--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -78,7 +78,7 @@
                         ko.utils.extend(result, binding);
                     }
                     else if (this.strict) {
-                        throw new Error("Missing binding for class '" + classes[i] + "'");
+                        throw new Error("Missing binding for class '" + clas + "'");
                     }
                 }
             }


### PR DESCRIPTION
If the option `strict` is true, and a binding class is specified but cannot be found in the bindings object, then it will throw an error. It's just a troubleshooting feature and adds to the size of the file, but I thought I'd submit it in case you might think it's useful.
