### PR TITLE
Suggestion: Routing function

### DIFF
--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -13,7 +13,7 @@
     var classBindingsProvider = function(bindings, options) {
         var virtualAttribute = "ko class:",
             existingProvider = new ko.bindingProvider(),
-            bindingRouter = typeof bindings == "function" ? bindings : function(className) { return this.bindings[className]; };
+            bindingRouter;
 
         options = options || {};
 
@@ -24,7 +24,10 @@
         this.fallback = options.fallback;
 
         //object that holds the binding classes, or a routing function that returns a binding class
-        this.bindings = bindings || {};
+        this.bindings = bindings || (bindings = {});
+
+        //function that returns a binding class, given the class name
+        bindingRouter = typeof bindings == "function" ? bindings : function(className) { return bindings[className]; };
 
         //determine if an element has any bindings
         this.nodeHasBindings = function(node) {
@@ -68,7 +71,7 @@
                 classes = classes.replace(/^(\s|\u00A0)+|(\s|\u00A0)+$/g, "").replace(/(\s|\u00A0){2,}/g, " ").split(' ');
                 //evaluate each class, build a single object to return
                 for (i = 0, j = classes.length; i < j; i++) {
-                    bindingAccessor = bindingRouter(classes[i]);
+                    bindingAccessor = bindingRouter(classes[i], classes);
                     if (bindingAccessor) {
                         binding = typeof bindingAccessor == "function" ? bindingAccessor.call(bindingContext.$data, bindingContext, classes) : bindingAccessor;
                         ko.utils.extend(result, binding);

--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -8,11 +8,12 @@
     }
 }(function(ko, exports, undefined) {
     //a bindingProvider that uses something different than data-bind attributes
-    //  bindings - an object that contains the binding classes
+    //  bindings - an object that contains the binding classes, or a routing function that returns a binding class
     //  options - is an object that can include "attribute" and "fallback" options
     var classBindingsProvider = function(bindings, options) {
         var virtualAttribute = "ko class:",
-            existingProvider = new ko.bindingProvider();
+            existingProvider = new ko.bindingProvider(),
+            bindingRouter = typeof bindings == "function" ? bindings : function(className) { return this.bindings[className]; };
 
         options = options || {};
 
@@ -22,7 +23,7 @@
         //fallback to the existing binding provider, if bindings are not found
         this.fallback = options.fallback;
 
-        //this object holds the binding classes
+        //object that holds the binding classes, or a routing function that returns a binding class
         this.bindings = bindings || {};
 
         //determine if an element has any bindings
@@ -67,7 +68,7 @@
                 classes = classes.replace(/^(\s|\u00A0)+|(\s|\u00A0)+$/g, "").replace(/(\s|\u00A0){2,}/g, " ").split(' ');
                 //evaluate each class, build a single object to return
                 for (i = 0, j = classes.length; i < j; i++) {
-                    bindingAccessor = this.bindings[classes[i]];
+                    bindingAccessor = bindingRouter(classes[i]);
                     if (bindingAccessor) {
                         binding = typeof bindingAccessor == "function" ? bindingAccessor.call(bindingContext.$data, bindingContext, classes) : bindingAccessor;
                         ko.utils.extend(result, binding);


### PR DESCRIPTION
In #5, you had suggested a fallback function to call if a binding cannot be found. This pull is a little different but gives the same capability and is more powerful. You can optionally pass in a function instead of an object for the `bindings` argument. This function takes the class name and classes array as arguments, and returns a binding accessor. This makes a few things possible:
- Organize bindings however you like. For example, you could use `.` to traverse subobjects:
  
  ``` html
  <div data-class="twitter.binding2">...</div>
  ```
  
  ``` js
  var bindings = {
    binding1: ...,
    twitter: {
      binding2: ...
    }
  };
  
  var bindingRouter = function(className) {
    var result, segments, i;
    result = bindings;
    segments = path.split('.');
    for (i = 0; i < segments.length; i++) {
      result = result[segments[i]];
      if (!result) return;
    }
    return result[className];
  };
  
  ko.bindingProvider.instance = new ko.classBindingProvider(bindingRouter);
  ```
- Or you could do the equivalent using a namespace parameter:
  
  ``` html
  <div data-class="binding2 namespace:twitter">...</div>
  ```
  
  ``` js
  var bindingRouter = function(className, classes) {
    var namespace, paramName = "namespace:";
    namespace = ko.utils.arrayFirst(classes, function(clas) {
      return clas.lastIndexOf(paramName, 0) === 0; // check whether clas starts with paramName
    });
    if (namespace) {
      namespace = namespace.substring(paramName.length);
      // get the binding object for namespace
    }
  };
  ```
- Suppress or alter the selection of a class binding based on the presence of another class:
  
  ``` html
  <div data-class="binding1 dont-use-binding1">...</div>
  ```
- Log troubleshooting info to the console:
  
  ``` js
  var bindingRouter = function(className, classes) {
    var result = bindings[className];
    if (result) {
      console.log("Found binding '" + className + "'");
    }
    else {
      console.log("Missing binding '" + className + "' from classes array [" + classes.join() + "]");
    }
    return result;
  };
  ```
