### PR TITLE
Add the ability to register bindings after instantiation

### DIFF
--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -24,6 +24,11 @@
 
         //this object holds the binding classes
         this.bindings = bindings || {};
+        
+        //allow bindings to be registered after instantiation
+        this.registerBindings = function(newBindings) {
+	        ko.utils.extend(this.bindings, newBindings);
+        };
 
         //determine if an element has any bindings
         this.nodeHasBindings = function(node) {


### PR DESCRIPTION
Added this.registerBindings function.  It accepts an additional bindings object to be added to the binding provider's binding list.

This allows individual KO modules register their own bindings before applying them in their specific portion of the dom.

``` javascript
var bindings = { ... }

ko.bindingProvider.instance = new ko.classBindingProvider(bindings);

ko.bindingProvider.instance.registerBindings({
  ...
})
```
