### PR TITLE
Binding registration keys

### DIFF
--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -30,11 +30,12 @@
         //this object holds a list of binding keys
         this.registeredBindingKeys = [];
         
+        // check if bindings are already registered
         this.bindingIsRegistered = function(bindingKey) {
 	        return this.registeredBindingKeys.indexOf(bindingKey) > -1;
         };
         
-        //allow bindings to be registered after instantiation
+        //allow bindings to be registered after instantiation, you can optionally pass a bindingKey for later reference
         this.registerBindings = function(newBindings, bindingKey) {
 	        if(bindingKey) {
 	        	if(this.bindingIsRegistered(bindingKey)) {


### PR DESCRIPTION
Adds a bindingRegistrationKeys array to optionally keep track of blocks of bindings that have been bound already and not bind them again.  It would also be interesting to explore some sort of unregister functionality, but I'm not sure it'd be that useful...

``` javascript
ko.bindingProvider.instance = new ko.classBindingProvider();

// returns true
ko.bindingProvider.instance.registerBindings({
  "test": { ... }
}, "myModule");

ko.bindingProvider.instance.bindingIsRegistered("myModule"); // returns true

// returns false, registration failed because bindings have already been registered with that key
ko.bindingProvider.instance.registerBindings({
  "test": { ... }
}, "myModule");
```
