### PR TITLE
Routing function with prefixing

### DIFF
--- a/examples/example-class-prefix.html
+++ b/examples/example-class-prefix.html
@@ -108,7 +108,7 @@
             bindings.count = function() { return { text: this.count } };
 
             //tell Knockout that we want to use an alternate binding provider
-            ko.bindingProvider.instance = new ko.classBindingProvider(bindings);
+            ko.bindingProvider.instance = new ko.classBindingProvider(bindings, { prefixingEnabled: true });
 
             var Item = function(name) {
                 this.name = ko.observable(name);

--- a/examples/example-class-prefix.html
+++ b/examples/example-class-prefix.html
@@ -1,0 +1,144 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>Knockout-ClassBindingProvider example</title>
+</head>
+<body>
+    <div id="content">
+        Editable: <input type="checkbox" data-class="editable" />
+        <ul data-class="items">
+            <li>
+                <input data-class="edit enabled" />
+                <button data-class="delete enabled">Delete</button>
+            </li>
+        </ul>
+        <button data-class="add enabled">Add Item</button>
+
+        <hr/>
+
+        <div data-class-prefix="test">
+            <div data-class-prefix="level1">
+                <span data-class="test"></span>
+            </div>
+            <div data-class-prefix="level2">
+                <span data-class="test"></span>
+            </div>
+        </div>
+
+        <!-- ko class: items -->
+        <div data-class="view"></div>
+        <!-- /ko -->
+    </div>
+
+    <hr/>
+
+    <div id="stats">
+        <ul data-class="stats">
+            <li>
+                <span data-class="stat"></span>:
+                <span data-class="count"></span>
+            </li>
+        </ul>
+    </div>
+
+    <script src="../ext/knockout-2.1.0.js"></script>
+    <script src="../src/knockout-classBindingProvider.js"></script>
+    <script type="text/javascript">
+        (function(ko) {
+            //create an object that holds our bindings
+            var bindings = {
+                editable: function() {
+                    return { checked: this.editable };
+                },
+                //this is an example of a binding tht is shared across scopes and fields
+                enabled: function(context) {
+                    return { enable: context.$root.editable };
+                },
+                items: function() {
+                    return { foreach: this.items };
+                },
+                edit: function() {
+                    return { value: this.name };
+                },
+                delete: function(context) {
+                    return { click: context.$parent.deleteItem };
+                },
+                add: function() {
+                    return { click: this.addItem };
+                },
+                view: function() {
+                    return { text: this.name };
+                },
+                test: {
+                    level1: {
+                        "test": function() {
+                            return {text: "testing1"};
+                        }
+                    },
+                    level2: {
+                        "test": function() {
+                            return {text: "testing2"};
+                        }
+                    }
+                }
+            };
+
+            //just a quick example of adding some logging to the bindings
+            var log = [];
+
+            var instrumentBinding = function(prop, binding, log) {
+                var stats = { count: ko.observable(0), prop: prop };
+                log.push(stats);
+                return function(context) {
+                    setTimeout(function() { stats.count(stats.count() + 1); }, 0);
+                    return binding.call(this, context);
+                };
+            };
+
+            //Don't instrument bindings becuase it interferes with our nested routing ability
+            /*for (var prop in bindings) {
+                if (bindings.hasOwnProperty(prop)) {
+                    bindings[prop] = instrumentBinding(prop, bindings[prop], log);
+                }
+            }*/
+
+            //add some bindings for the stats (that are not instrumented themselves)
+            bindings.stats = function() { return { foreach: this } };
+            bindings.stat = function() { return { text: this.prop } };
+            bindings.count = function() { return { text: this.count } };
+
+            //tell Knockout that we want to use an alternate binding provider
+            ko.bindingProvider.instance = new ko.classBindingProvider(bindings);
+
+            var Item = function(name) {
+                this.name = ko.observable(name);
+            };
+
+            var ViewModel = function(items) {
+                var self = this;
+
+                this.editable = ko.observable(true);
+
+                this.items = ko.observableArray(items);
+
+                this.addItem = function() {
+                    self.items.push(new Item("New"));
+                };
+
+                this.deleteItem = function(item) {
+                    self.items.remove(item);
+                };
+            };
+
+            ko.applyBindings(new ViewModel([
+                new Item("Pen"),
+                new Item("Pencil"),
+                new Item("Eraser")
+            ]), document.getElementById("content"));
+
+            ko.applyBindings(log, document.getElementById("stats"));
+
+        })(ko);
+    </script>
+</body>
+</html>

--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -93,7 +93,7 @@
             if (node.nodeType === 1) {
                 ko.utils.domData.set(node, "class-prefix", prefix);
                 // set prefix on nodes with bindings for readability in the inspector
-                if(this.nodeHasBindings(node)) {
+                if (this.nodeHasBindings(node)) {
                     node.setAttribute(this.prefixAttribute, prefix);
                 }
             }
@@ -101,7 +101,9 @@
 
         //Finds and returns combined prefix for node
         this.getPrefix = function (node) {
-            if (!node.parentElement) {
+            var parentElement = node.parentElement || node.parentNode;
+
+            if (!parentElement) {
                 // We recursed to the body tag and didn't find any prefixes.
                 // Return "$root" so that we don't have to do it again.
                 // Todo: Check instead for the node we called ko.applyBindings on
@@ -110,10 +112,10 @@
 
             var prefix = null;
 
-            if(node.nodeType === 1) {
-                if(ko.utils.domData.get(node, "class-prefix") !== undefined) {
+            if (node.nodeType === 1) {
+                if (ko.utils.domData.get(node, "class-prefix") !== undefined) {
                     prefix = ko.utils.domData.get(node, "class-prefix");
-                } else if(node.getAttribute(this.prefixAttribute) !== null) {
+                } else if (node.getAttribute(this.prefixAttribute) !== null) {
                     prefix = node.getAttribute(this.prefixAttribute);
                 }
             }
@@ -124,13 +126,13 @@
                     return prefix;
                 } else if (prefix.indexOf("$root") === -1) {
                     // Has prefix without root defined? Search for root and return combined.
-                    prefix = this.getPrefix(node.parentElement) + "." + prefix;
+                    prefix = this.getPrefix(parentElement) + "." + prefix;
                     this.cachePrefix(node, prefix);
                     return prefix;
                 }
             } else {
                 // Doesn't have prefix? Traverse up the DOM looking for one and return it.
-                prefix = this.getPrefix(node.parentElement);
+                prefix = this.getPrefix(parentElement);
                 this.cachePrefix(node, prefix);
                 return prefix;
             }

--- a/src/knockout-classBindingProvider.js
+++ b/src/knockout-classBindingProvider.js
@@ -1,4 +1,4 @@
-!(function(factory) {
+!(function (factory) {
     //AMD
     if (typeof define === "function" && define.amd) {
         define(["knockout", "exports"], factory);
@@ -6,18 +6,21 @@
     } else {
         factory(ko);
     }
-}(function(ko, exports, undefined) {
+}(function (ko, exports, undefined) {
     //a bindingProvider that uses something different than data-bind attributes
     //  bindings - an object that contains the binding classes
-    //  options - is an object that can include "attribute", "virtualAttribute", bindingRouter, and "fallback" options
-    var classBindingsProvider = function(bindings, options) {
+    //  options - is an object that can include "attribute", "prefixAttribute", "virtualAttribute", bindingRouter, and "fallback" options
+    var classBindingsProvider = function (bindings, options) {
         var existingProvider = new ko.bindingProvider();
 
         options = options || {};
 
         //override the attribute
         this.attribute = options.attribute || "data-class";
-        
+
+        //override the prefix attribute
+        this.prefixAttribute = options.prefixAttribute || "data-class-prefix";
+
         //override the virtual attribute
         this.virtualAttribute = "ko " + (options.virtualAttribute || "class") + ":";
 
@@ -28,24 +31,43 @@
         this.bindings = bindings || {};
 
         //returns a binding class, given the class name and the bindings object
-        this.bindingRouter = options.bindingRouter ? options.bindingRouter : function(className, bindings) {
-            var classPath = className.split(".");
-            var bindingObject = bindings;
+        this.bindingRouter = options.bindingRouter ? options.bindingRouter : function (className, bindings, classPrefix) {
+            var i, j, classPath, bindingObject;
 
-            for (var i = 0; i < classPath.length; i++) {
-                bindingObject = bindingObject[classPath[i]];
-            };
+            //if there is a prefix, prepend it to the class name
+            if (classPrefix && className.indexOf("$root") === -1) {
+                className = classPrefix + "." + className;
+            }
+
+            className = className.replace("$root", "").replace(/(^\s*\.)|(\.\s*$)/g, '');
+
+            //if the class name matches a property directly, then return it
+            if (bindings[className]) {
+                return bindings[className];
+            }
+
+            //search for sub-properites that might contain the bindings
+            classPath = className.split(".");
+            bindingObject = bindings;
+
+            try {
+                for (i = 0, j = classPath.length; i < j; i++) {
+                    bindingObject = bindingObject[classPath[i]];
+                }
+            } catch (e) {
+                throw "Cannot find binding: " + className;
+            }
 
             return bindingObject;
         };
-        
+
         //allow bindings to be registered after instantiation
-        this.registerBindings = function(newBindings) {
-	        ko.utils.extend(this.bindings, newBindings);
+        this.registerBindings = function (newBindings) {
+            ko.utils.extend(this.bindings, newBindings);
         };
 
         //determine if an element has any bindings
-        this.nodeHasBindings = function(node) {
+        this.nodeHasBindings = function (node) {
             var result, value;
 
             if (node.nodeType === 1) {
@@ -63,12 +85,54 @@
             return result;
         };
 
+        //cache combined prefix on real nodes
+        this.cachePrefix = function (node, prefix) {
+            if (node.nodeType === 1) {
+                node.setAttribute(this.prefixAttribute, prefix);
+            }
+        };
+
+        //Finds and returns combined prefix for node
+        this.getPrefix = function (node) {
+            if (!node.parentElement) {
+                // We recursed to the body tag and didn't find any prefixes.
+                // Return "$root" so that we don't have to do it again.
+                return "$root";
+            }
+
+            var prefix = (node.nodeType === 1 && node.getAttribute(this.prefixAttribute) !== null) ? node.getAttribute(this.prefixAttribute) : null;
+
+            if (prefix !== null) {
+                if (prefix === "$root" || (prefix.indexOf("$root") >= 0 && prefix !== "$root")) {
+                    // Has prefix with root defined? Return it.
+                    return prefix;
+                } else if (prefix.indexOf("$root") === -1) {
+                    // Has prefix without root defined? Search for root and return combined.
+                    prefix = this.getPrefix(node.parentElement) + "." + prefix;
+                    this.cachePrefix(node, prefix);
+                    return prefix;
+                }
+            } else {
+                // Doesn't have prefix? Traverse up the DOM looking for one and return it.
+                prefix = this.getPrefix(node.parentElement);
+                this.cachePrefix(node, prefix);
+                return prefix;
+            }
+        };
+
+        // Cleans up prefix
+        // Return prefixes without "$root" or any leading/trailing periods and whitespace
+        this.getCleanPrefix = function (node) {
+            return this.getPrefix(node).replace("$root", "").replace(/(^\s*\.)|(\.\s*$)/g, '');
+        };
+
         //return the bindings given a node and the bindingContext
-        this.getBindings = function(node, bindingContext) {
+        this.getBindings = function (node, bindingContext) {
             var i, j, bindingAccessor, binding,
                 result = {},
                 value, index,
-                classes = "";
+                classes = "",
+                prefix = this.getCleanPrefix(node);
 
             if (node.nodeType === 1) {
                 classes = node.getAttribute(this.attribute);
@@ -84,9 +148,10 @@
 
             if (classes) {
                 classes = classes.replace(/^(\s|\u00A0)+|(\s|\u00A0)+$/g, "").replace(/(\s|\u00A0){2,}/g, " ").split(' ');
+
                 //evaluate each class, build a single object to return
                 for (i = 0, j = classes.length; i < j; i++) {
-                    bindingAccessor = this.bindingRouter(classes[i], this.bindings);
+                    bindingAccessor = this.bindingRouter(classes[i], this.bindings, prefix);
                     if (bindingAccessor) {
                         binding = typeof bindingAccessor == "function" ? bindingAccessor.call(bindingContext.$data, bindingContext, classes) : bindingAccessor;
                         ko.utils.extend(result, binding);
@@ -94,7 +159,7 @@
                 }
             }
             else if (this.fallback) {
-                result = existingProvider.getBindings(node,bindingContext);
+                result = existingProvider.getBindings(node, bindingContext);
             }
 
             return result;


### PR DESCRIPTION
I extended the `getBindings` method to call a `getCleanPrefix` function that recurses up the DOM tree looking for nodes with a `data-class-prefix` attribute and returning the complete prefix once it hits the `<body>` tag or an element with a `data-class-prefix` containing "$root".  

The newly generated class prefix is then passed to the binding router and prepended to the class name before it attempts to look up the binding in the bindings object. 

This allows you to write HTML like this:

``` html
<div data-class-prefix="$root.test">
    <div data-class-prefix="level1">
        <span data-class="test"></span>
        <span data-class="test2"></span>
    </div>
    <div data-class-prefix="level2">
        <span data-class="test"></span>
        <span data-class="test2"></span>
    </div>
</div>
```

instead of...

``` html
<div>
    <div>
        <span data-class="test.level1.test"></span>
        <span data-class="test.level1.test2"></span>
    </div>
    <div>
        <span data-class="test.level2.test"></span>
        <span data-class="test.level2.test2"></span>
    </div>
</div>
```
## Technical Details

The `getPrefix` method decorates all child nodes of an element with a `data-class-prefix` attribute containing "$root".  This is easiest to understand if you open up your inspector and look at the generated HTML.  It adds the `data-class-prefix` attribute to all nodes, so that the second time a child element on the same branch goes to get its prefix, it doesn't have to recurse all the way up the tree again.  

Knockout's `ko.domData` might be an effective way to clean things up, but I'm not sure it's the most straightforward thing to implement and might be a source of memory leaks if DOM elements are removed outside of Knockout.

Thoughts?
